### PR TITLE
feat: add APISIX GitHub Action CI support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,17 @@
+titleOnly: true
+allowRevertCommits: true
+types:
+  - feat
+  - fix
+  - bugfix
+  - docs
+  - style
+  - refactor
+  - reformat
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+  - change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+      - "master"
+  pull_request:
+    branches:
+      - "main"
+      - "master"
+
+jobs:
+  unit-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - ubuntu-18.04
+          - ubuntu-20.04
+        os_name:
+          - linux
+
+    runs-on: ${{ matrix.platform }}
+    env:
+      SERVER_NAME: ${{ matrix.os_name }}
+
+    steps:
+      - name: Check out APISIX
+        uses: actions/checkout@v2.3.4
+        with:
+          path: apisix-plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,7 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           path: apisix-plugin
+
+      - name: Check out APISIX repo
+        run: |
+          sudo ./ci/utils/linux-common-runnner.sh get_apisix_code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
       - name: Check out APISIX repo
         run: |
           sudo ./ci/utils/linux-common-runnner.sh get_apisix_code
+        working-directory: apisix-plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       SERVER_NAME: ${{ matrix.os_name }}
 
     steps:
-      - name: Check out APISIX
+      - name: Check out APISIX plugins
         uses: actions/checkout@v2.3.4
         with:
           path: apisix-plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ jobs:
       matrix:
         platform:
           - ubuntu-20.04
-        os_name:
-          - linux
 
     runs-on: ${{ matrix.platform }}
-    env:
-      SERVER_NAME: ${{ matrix.os_name }}
 
     steps:
       - name: Check out APISIX plugins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - "main"
-      - "master"
   pull_request:
     branches:
       - "main"
-      - "master"
 
 jobs:
   unit-test:
@@ -16,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-18.04
           - ubuntu-20.04
         os_name:
           - linux

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE ignore
+.idea
+
 # Compiled Lua sources
 luac.out
 

--- a/ci/utils/linux-common-runnner.sh
+++ b/ci/utils/linux-common-runnner.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+VAR_CUR_PATH="$(cd $(dirname ${0}); pwd)"
+
+source "${VAR_CUR_PATH}/linux-common.sh"
+
+# =======================================
+# Linux common config
+# =======================================
+get_apisix_code() {
+    # ${1} branch name
+    git_branch=${1:release/2.10}
+    git clone --recursive https://github.com/apache/apisix.git -b "${git_branch}" && cd apisix || exit 1
+}
+
+# =======================================
+# Entry
+# =======================================
+case_opt=$1
+shift
+
+case ${case_opt} in
+get_apisix_code)
+    get_apisix_code "$@"
+    ;;
+*)
+    func_echo_error_status "Unknown method: ${case_opt}"
+    ;;
+esac

--- a/ci/utils/linux-common-runnner.sh
+++ b/ci/utils/linux-common-runnner.sh
@@ -12,7 +12,7 @@ source "${VAR_CUR_PATH}/linux-common.sh"
 get_apisix_code() {
     # ${1} branch name
     git_branch=${1:-release/2.10}
-    git clone --recursive https://github.com/apache/apisix.git -b "${git_branch}" && cd apisix || exit 1
+    git clone --depth 1 --recursive https://github.com/apache/apisix.git -b "${git_branch}" && cd apisix || exit 1
 }
 
 # =======================================

--- a/ci/utils/linux-common-runnner.sh
+++ b/ci/utils/linux-common-runnner.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 VAR_CUR_PATH="$(cd $(dirname ${0}); pwd)"
 
 source "${VAR_CUR_PATH}/linux-common.sh"

--- a/ci/utils/linux-common-runnner.sh
+++ b/ci/utils/linux-common-runnner.sh
@@ -9,7 +9,7 @@ source "${VAR_CUR_PATH}/linux-common.sh"
 # =======================================
 get_apisix_code() {
     # ${1} branch name
-    git_branch=${1:release/2.10}
+    git_branch=${1:-release/2.10}
     git clone --recursive https://github.com/apache/apisix.git -b "${git_branch}" && cd apisix || exit 1
 }
 

--- a/ci/utils/linux-common.sh
+++ b/ci/utils/linux-common.sh
@@ -1,0 +1,31 @@
+set -${ENTRYPOINT_MODE:-e}
+
+# =======================================
+# Linux basic extension module
+# =======================================
+
+_color_red='\E[1;31m'
+_color_green='\E[1;32m'
+_color_yellow='\E[1;33m'
+_color_blue='\E[1;34m'
+_color_wipe='\E[0m'
+
+
+function func_echo_status() {
+    printf "[%b info %b] %b\n" "${_color_blue}" "${_color_wipe}" "${1}"
+}
+
+
+function func_echo_warn_status() {
+    printf "[%b info %b] %b\n" "${_color_yellow}" "${_color_wipe}" "${1}"
+}
+
+
+function func_echo_success_status() {
+    printf "[%b info %b] %b\n" "${_color_green}" "${_color_wipe}" "${1}"
+}
+
+
+function func_echo_error_status() {
+    printf "[%b info %b] %b\n" "${_color_red}" "${_color_wipe}" "${1}"
+}


### PR DESCRIPTION
This PR add basic APISIX GitHub action support for `apisix-plugin-template`, then we can have a CI infrastructure to verify that everything is working as expected before merge it.

> TODO
- [x] add basic GitHub Action support
- [x] add APISIX CI utils script 